### PR TITLE
Player Space motion controls as a composite binding

### DIFF
--- a/Runtime/PlayerSpaceMotionComposite.cs
+++ b/Runtime/PlayerSpaceMotionComposite.cs
@@ -1,0 +1,76 @@
+﻿using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.Utilities;
+
+namespace MoreStories.GyroTools
+{
+    /// <summary>
+    /// This is a composite binding that transforms gyroscope and accelerometer values into Player Space
+    /// and computes a 2D vector representing an angular velocity expressed in degrees.
+    /// It can also be used with Unity's built-in gyro and accel actions for mobile devices and console platforms.
+    /// </summary>
+#if UNITY_EDITOR
+    [UnityEditor.InitializeOnLoad]
+#endif
+    [DisplayStringFormat("{gyroscope} & {accelerometer}")]
+    public class PlayerSpaceMotionComposite : InputBindingComposite<Vector2>
+    {
+        [InputControl(layout = "Vector3")]
+        public int accelerometer;
+
+        [InputControl(layout = "Vector3")]
+        public int gyroscope;
+
+        public float sensitivity = 1f;
+
+        private float _lastCall = Time.unscaledTime;
+        private Vector3 _gravity;
+
+#if UNITY_EDITOR
+        static PlayerSpaceMotionComposite()
+        {
+            Initialize();
+        }
+#endif
+        [RuntimeInitializeOnLoadMethod]
+        static void Initialize()
+        {
+            InputSystem.RegisterBindingComposite<PlayerSpaceMotionComposite>();
+        }
+
+        // Implementation adapted from http://gyrowiki.jibbsmart.com/blog:player-space-gyro-and-alternatives-explained
+        public override Vector2 ReadValue(ref InputBindingCompositeContext context)
+        {
+            const float accelInfluence = .02f;
+            const float yawRelaxFactor = 1.41f;
+
+            var time = Time.unscaledTime;
+            var deltaTime = time - _lastCall;
+
+            _lastCall = time;
+
+            var gyro = context.ReadValue<Vector3, Vector3MagnitudeComparer>(gyroscope);
+            var accel = context.ReadValue<Vector3, Vector3MagnitudeComparer>(accelerometer);
+
+            var rotation = Quaternion.AngleAxis(Vector3.Magnitude(gyro) * deltaTime, -gyro);
+
+            // rotate gravity vector
+            _gravity = rotation * _gravity;
+
+            // nudge towards gravity according to current acceleration
+            var newGravity = -accel;
+            _gravity += (newGravity - _gravity) * accelInfluence;
+
+            var gravNorm = _gravity.normalized;
+
+            // use world yaw for yaw direction, local combined yaw for magnitude
+            var worldYaw = gyro.y * gravNorm.y + gyro.z * gravNorm.z; // dot product but just yaw and roll
+
+            return new Vector2(
+                -1f * Mathf.Sign(worldYaw) * Mathf.Min(Mathf.Abs(worldYaw) * yawRelaxFactor, new Vector2(gyro.y, gyro.z).magnitude) * sensitivity * Mathf.Rad2Deg * deltaTime,
+                -1f * gyro.x * sensitivity * Mathf.Rad2Deg * deltaTime
+            );
+        }
+    }
+}

--- a/Runtime/PlayerSpaceMotionComposite.cs.meta
+++ b/Runtime/PlayerSpaceMotionComposite.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d5538474d32c4069830f9a1157c1a49a
+timeCreated: 1773214546


### PR DESCRIPTION
This is a proposal for implementing Player Space motion controls, which is useful for aiming or moving a cursor on a 2D plane, as a composite binding.

To use it and test it, create a Vector2 action and add this composite as a possible binding. There is a sensitivity parameter that can scale the output value, I have found that 1 is good for camera aiming, and higher values such as 2 or 3 are good for moving cursors.

The pros of using a composite binding is that this implementation will also accept Unity's native Gyroscope and Accelerometer actions as an input, which means that it's also usable on mobile devices and console platforms.

My initial attempt was to realise this implementation as a Processor, but I couldn't for the following reasons:
* Processors cannot be stateful [as per the official docs](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.14/api/UnityEngine.InputSystem.InputProcessor-1.html#UnityEngine_InputSystem_InputProcessor_1_remarks), and I needed a state for computing the gravity vector over time.
* The goal being to project 3D angular velocity on a 2D plane, it was not possible to convert the incoming `Vector3Control` into a `Vector2Control` with a processor.

For more information about Player Space in the context of motion controls, I invite you to check out [this gyrowiki article](http://gyrowiki.jibbsmart.com/blog:player-space-gyro-and-alternatives-explained).